### PR TITLE
Handle and catch sbcSets() errors

### DIFF
--- a/tampermonkey-ai-sbc.user.js
+++ b/tampermonkey-ai-sbc.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         FIFA Auto SBC
 // @namespace    http://tampermonkey.net/
-// @version      25.1.11
+// @version      25.1.12
 // @description  automatically solve EAFC 25 SBCs using the currently available players in the club with the minimum cost
 // @author       TitiroMonkey
 // @match        https://www.easports.com/*/ea-sports-fc/ultimate-team/web-app/*
@@ -768,7 +768,7 @@ color:black
                     resolve(res.data);
                 }
             });
-        });
+        }).catch((e) => { console.log(e) });
     };
 
     const getChallenges = async function (set) {
@@ -785,7 +785,7 @@ color:black
                     }
                 }
             );
-        });
+        }).catch((e) => { console.log(e) });
     };
 
     const loadChallenge = async function (currentChallenge) {
@@ -809,6 +809,12 @@ color:black
         //Get SBC Data if given a setId
 
         let sbcData = await sbcSets();
+        if (sbcData === undefined) {
+            console.log('SBC DATA is not available')
+            createSBCTab();
+            return null
+        }
+
         let sbcSet = sbcData.sets.filter((e) => e.id == sbcId)
 
         if(sbcSet.length==0){
@@ -2172,6 +2178,10 @@ console.log( item.rating,item,PriceItems[item.definitionId],getSBCPrice(item,[])
         services.SBC.repository.reset()
 
         let sets = await sbcSets();
+        if (sets === undefined) {
+            console.log('createSBCTab: sets are undefined')
+            return null
+        }
         let favourites = sets.categories.filter((f) => f.name == 'Favourites')[0]
         .setIds;
         let favouriteSBCSets = sets.sets.filter((f) => favourites.includes(f.id)).sort((a, b) => b.timesCompleted - a.timesCompleted)

--- a/tampermonkey-ai-sbc.user.js
+++ b/tampermonkey-ai-sbc.user.js
@@ -2175,6 +2175,8 @@ console.log( item.rating,item,PriceItems[item.definitionId],getSBCPrice(item,[])
     };
 
     const createSBCTab = async () => {
+        if (!getSettings(0,0,'showSbcTab')) return
+
         services.SBC.repository.reset()
 
         let sets = await sbcSets();
@@ -2446,6 +2448,10 @@ console.log( item.rating,item,PriceItems[item.definitionId],getSBCPrice(item,[])
         createNumberSpinner(sbcUITile,'Price Cache Minutes','priceCacheMinutes',1,1440,getSettings(0,0,'priceCacheMinutes'),(numberspinnerPCM)=>{
             saveSettings(0,0,'priceCacheMinutes',numberspinnerPCM.getValue())
         })
+        createToggle(sbcUITile,'Show SBCs Tab','showSbcTab',getSettings(0,0,'showSbcTab'),(toggleSP)=>{
+            saveSettings(0,0,'showSbcTab',toggleSP.getToggleState())
+        })
+
         let panel = createPanel()
         let clearPricesBtn = createButton('clearPrices','Clear All Prices',()=>{cachedPriceItems=null;localStorage.removeItem(PRICE_ITEMS_KEY)})
         panel.appendChild(clearPricesBtn)
@@ -2616,6 +2622,7 @@ console.log( item.rating,item,PriceItems[item.definitionId],getSBCPrice(item,[])
         maxRating:99,
         repeatCount:0,
         showPrices:true,
+        showSbcTab:true,
         useDupes:true,
         autoOpenPacks:false,
         saveTotw:false


### PR DESCRIPTION
**Problem**
Sometimes when you start solving SBC it blocks the screen with the progress overlay, however it doesn't start solving, nor the countdown starts ticking. And the only way to make it work again is by refreshing the page.
It happens because `services.SBC.requestSets()` inside `sbcSets()` function might return errors, such as with http codes 512, 521 or 429, which I guess might be caused by rate limiting due to that request is called quite frequently.

**Workaround**
To avoid blocking the screen, we can catch errors instead and just show a notification with error. After waiting few seconds and trying again it usually works fine. Thus, you don't have to refresh the page to make it work again.